### PR TITLE
feat: Add Claude Code guidance files for repository

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,90 @@
+# Codebase Standards
+
+Canonical design principles for the MCP Slicer Bridge. This file should rarely change.
+
+## Design Principles
+
+### 1. Singleton HTTP Client
+`SlicerClient` uses thread-safe double-checked locking. All HTTP communication goes through this single instance (note: per-request connections, not session pooling, due to Slicer WebServer closing connections immediately).
+
+**Why**: Prevents connection exhaustion, ensures consistent retry/circuit breaker behavior across all requests.
+
+### 2. Retry with Exponential Backoff
+Failed HTTP requests retry 3 times with delays: 1s → 2s → 4s. Only connection errors trigger retries; timeouts do not.
+
+**Why**: Slicer may be temporarily busy processing images. Exponential backoff prevents thundering herd.
+
+### 3. Circuit Breaker Pattern
+After 5 consecutive failures, circuit opens for 30 seconds. During this time, requests fail fast without attempting HTTP calls. After the timeout, circuit transitions to HALF_OPEN state and allows one test request - if it succeeds, circuit closes; if it fails, circuit reopens.
+
+**Why**: Prevents resource exhaustion when Slicer is down. Allows Slicer to recover without being hammered.
+
+### 4. Input Validation at Tool Boundary
+Node IDs: ASCII-only, max 256 chars. Segment names: NFKC Unicode normalization, max 256 chars.
+
+**Why**: Defense-in-depth. Even though we trust Slicer, we validate before sending to prevent injection.
+
+### 5. stdio Transport
+MCP communication uses stdin/stdout. Logs go to stderr as JSON.
+
+**Why**: MCP protocol requirement. Keeps protocol messages separate from diagnostic output.
+
+## Anti-Patterns to Avoid
+
+### Over-Engineering
+- Don't add authentication/authorization - this is designed for localhost only
+- Don't add database persistence - state lives in Slicer's MRML scene
+- Don't create abstractions for single-use operations
+- Don't add configuration options that aren't needed yet
+
+### Breaking Simplicity
+- Don't replace `requests` with async HTTP unless there's a measured performance need
+- Don't add middleware layers between tools and SlicerClient
+- Don't create wrapper classes around Slicer responses
+
+### Scope Creep
+- Don't add features beyond MCP tool/resource interface
+- Don't try to sandbox `execute_python` - Slicer's whole API must be accessible
+- Don't add GUI components - this is a CLI bridge
+
+## Security Boundaries
+
+### What This Is
+- Educational/research tool for **localhost only**
+- No encryption, no authentication, no multi-user support
+- `execute_python` runs arbitrary code by design
+
+### What This Is NOT
+- Clinical/production system
+- HIPAA/GDPR compliant
+- Suitable for patient data
+- Safe for remote access
+
+### Audit Logging
+All `execute_python` calls are logged with timestamp, code hash, and result. This is for debugging and research reproducibility, not security enforcement.
+
+## Architectural Invariants
+
+These must always remain true:
+
+1. **Single HTTP Client**: All Slicer communication through `SlicerClient` singleton
+2. **Fail-Fast on Circuit Open**: Never queue or retry when circuit is open
+3. **No State in Bridge**: All state lives in Slicer's MRML scene
+4. **Logs to stderr**: stdout is reserved for MCP protocol only
+5. **Validation Before HTTP**: All inputs validated before reaching SlicerClient
+6. **Constants Centralized**: All magic numbers and config values in `constants.py`
+
+## Code Conventions
+
+### Imports
+Standard library first, then third-party, then local. Sorted by `ruff`.
+
+### Error Handling
+- `SlicerConnectionError` - retryable network errors
+- `SlicerTimeoutError` - not retried (Slicer is busy)
+- `CircuitBreakerOpen` - fail fast, don't attempt connection
+
+### Naming
+- Tools: verb_noun (e.g., `capture_screenshot`, `measure_volume`)
+- Resources: `slicer://` URI scheme
+- Constants: UPPER_SNAKE_CASE

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,1 @@
+{"mcpServers":{"MCP_DOCKER":{"command":"docker","args":["mcp","gateway","run"],"type":"stdio"}}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MCP (Model Context Protocol) server bridging Claude Code to 3D Slicer for AI-assisted medical image analysis. Uses FastMCP framework with stdio transport.
+
+## Commands
+
+```bash
+# Install dependencies
+uv sync
+
+# Run tests (no Slicer required)
+uv run pytest -v
+
+# Run integration tests (requires Slicer WebServer on localhost:2016)
+uv run pytest -v -m integration
+
+# Run with coverage
+uv run pytest --cov=slicer_mcp --cov-report=html
+
+# Format code
+uv run black src tests
+
+# Lint code
+uv run ruff check src tests
+
+# Run the MCP server
+uv run slicer-mcp
+```
+
+## Architecture
+
+```
+Claude Code ──(MCP/stdio)──▶ server.py ──(HTTP)──▶ Slicer WebServer (localhost:2016)
+                               │
+                               ├─ tools.py      (7 tools: capture_screenshot, execute_python, etc.)
+                               ├─ resources.py  (3 resources: scene, volumes, status)
+                               └─ slicer_client.py (HTTP client with retry + circuit breaker)
+```
+
+### Key Components
+
+| File | Purpose |
+|------|---------|
+| `src/slicer_mcp/server.py` | FastMCP server entry point, registers tools/resources |
+| `src/slicer_mcp/slicer_client.py` | Singleton HTTP client with retry (3x backoff) and circuit breaker |
+| `src/slicer_mcp/tools.py` | 7 MCP tools (capture_screenshot, execute_python, measure_volume, etc.) |
+| `src/slicer_mcp/resources.py` | 3 MCP resources (slicer://scene, slicer://volumes, slicer://status) |
+| `src/slicer_mcp/circuit_breaker.py` | Circuit breaker pattern (CLOSED→OPEN→HALF_OPEN) |
+| `src/slicer_mcp/constants.py` | Centralized configuration and validation limits |
+
+### Data Flow
+
+1. Claude Code sends MCP request via stdio (JSON-RPC 2.0)
+2. FastMCP routes to appropriate tool/resource handler
+3. Handler validates input, calls SlicerClient
+4. SlicerClient makes HTTP request to Slicer WebServer with retry logic
+5. Response flows back through the same path
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SLICER_URL` | `http://localhost:2016` | Slicer WebServer URL |
+| `SLICER_TIMEOUT` | `30` | HTTP timeout in seconds |
+| `SLICER_AUDIT_LOG` | *(none)* | Path to audit log for execute_python |
+| `SLICER_METRICS_ENABLED` | `false` | Enable Prometheus metrics |
+
+## Test Markers
+
+- `@pytest.mark.integration` - Requires running Slicer instance
+- `@pytest.mark.benchmark` - Performance benchmarks
+
+## Code Style
+
+- **Formatter**: Black (100 char line length)
+- **Linter**: Ruff (rules: E, F, W, I, N, UP)
+- **Python**: 3.10+
+- **Type hints**: Used throughout
+
+## See Also
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) - Detailed design decisions
+- [SPECIFICATION.md](SPECIFICATION.md) - Complete API reference
+- [.claude/CLAUDE.md](.claude/CLAUDE.md) - Canonical codebase standards

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ dev = [
     "httpx>=0.28.1",
     "pytest>=9.0.1",
     "pytest-asyncio>=1.3.0",
+    "pytest-cov>=4.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` at repository root with operational guidance (build/test/lint commands, architecture overview, environment variables, key component locations)
- Add `.claude/CLAUDE.md` with canonical codebase standards that should rarely change (design principles, anti-patterns to avoid, security boundaries, architectural invariants)

These files help future Claude Code instances maintain consistency and prevent architectural drift when working in this repository.

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify .claude/CLAUDE.md is accessible and renders correctly
- [ ] Confirm commands in CLAUDE.md work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)